### PR TITLE
Update README about setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # camome_voice
+## Setup for execution environment
++ Confirm pip version and python version
+
+gRPC Python is supported for use with Python 2.7 or Python 3.4 or higher.
+Ensure you have pip version 9.0.1 or higher.
+
++ Install `grpcio`
+
+```
+$ pip install grpcio
+```
+`grpcio` is gRPC library for python.
+You need `grpcio` for execute python include gRPC.
+
+
+## Setup for compile environment
++ Confirm pip version and python version
+
+gRPC Python is supported for use with Python 2.7 or Python 3.4 or higher.
+Ensure you have pip version 9.0.1 or higher.
+
++ Install `grpcio-tools`
+```
+$ pip install grpcio
+```
+`grpcio-tools` include the protocol buffer compiler `protoc`.
+So, you need `grpcio-tools` for compile.
+
+
+## Compile `.proto` file
+Given protobuf include directories `$INCLUDE_DIR`, an output directory `$OUTPUT_DIR`, and proto files `$PROTO_FILES`, invoke as:
+```
+$ python -m grpc.tools.protoc -I$INCLUDE_DIR --python_out=$OUTPUT_DIR --grpc_python_out=$OUTPUT_DIR $PROTO_FILES
+```
+
+
+## Reference
+0. [grpc(Google documents)](https://grpc.io/docs/quickstart/python.html)
+0. [grpcio(Github)](https://github.com/grpc/grpc/tree/master/src/python/grpcio)
+0. [grpcio-tools(GitHub)](https://github.com/grpc/grpc/tree/master/tools/distrib/python/grpcio_tools)


### PR DESCRIPTION
#1 に対するPRである．

### 今回やったこと
+ pythonでgrpcを利用するために必要なライブラリについて調査した.
その結果，grpcを含むプログラムの実行環境には`grpcio`が必要なことがわかった．
`proto`ファイルのコンパイルには，`grpcio-tools`が必要なことがわかった．

+ 上記の調査結果をもとに，READMEに環境構築に関する情報を記述した．

### 今回の経緯
+ [grpc(Google)](https://grpc.io/docs/quickstart/)を参考に，pythonでgrpcを利用するために必要なライブラリについて調査した結果，`grpcio`と`grpcio-tools`が必要なことがわかった．
上記のページには，「`grpcio-tools`は，`.proto`ファイルのコンパイラである`protoc`を含んでいるライブラリである」と記述されている．
また，`grpcio`と`grpcio-tools`の依存関係について調べると，`grpcio-tools`は，`grpcio`を含んでいることがわかった．
このことから，`proto`ファイルのコンパイルには，`grpcio-tools`が必要であると言える．

+ しかし，grpcを含むプログラムの実行環境に`grpcio-tools`が必要なのかどうかは上記のページには記述されていない．[grpcio(GitHub)](https://github.com/grpc/grpc/tree/master/src/python/grpcio)や，[grpcio-tools(GitHub)](https://github.com/grpc/grpc/tree/master/tools/distrib/python/grpcio_tools)などを参考に調査したが，該当する情報は記述されていなかった．
そこで，grpcを含むプログラムの実行環境に`grpcio-tools`が必要なのかどうかを調べるために実験を行なった．
本実験では，`grpcio`と`grpcio`の利用に必要なライブラリのみをインストールした状態で，grpcを含むプログラムを実行できるかどうかを確認した．
その結果，grpcを含むプログラムを実行することができた．
このことから，grpcを含むプログラムの実行環境には`grpcio`が必要であり，`grpcio-tools`は必要ないと言える．

## 今後の方針
+ 上記の結果から，Raspberry Piを利用した開発は，以下の方針で行うことが考えられる．
  + `.proto`ファイルのコンパイルは各自の計算機で行い，本リポジトリにコンパイルにより生成されたファイルをpushする．
  + Raspberry Pi側では，本リポジトリをpullし，プログラムの実行のみ行う．

このように，開発環境と実行環境を分けることで，Raspberry Pi に最低限のライブラリのみをインストールした状態で，開発を進められると考えられる．
